### PR TITLE
Make daily energy compatible with energy management

### DIFF
--- a/custom_components/kostal/sensor.py
+++ b/custom_components/kostal/sensor.py
@@ -72,11 +72,7 @@ class PikoSensor(SensorEntity):
         self.model = info[1]
         if self._unit_of_measurement == ENERGY_KILO_WATT_HOUR:
             self._attr_device_class = DEVICE_CLASS_ENERGY
-            if self._sensor == SENSOR_TYPES["daily_energy"][0]:
-                self._attr_last_reset = dt.as_utc(dt.start_of_local_day())
-                self._attr_state_class = STATE_CLASS_MEASUREMENT
-            else:
-                self._attr_state_class = STATE_CLASS_TOTAL_INCREASING
+            self._attr_state_class = STATE_CLASS_TOTAL_INCREASING
 
     @property
     def name(self):


### PR DESCRIPTION
I recently started using your integration, first of all: Thanks!

I wanted to use the daily energy in the energy management dashboard instead of the overall total as it is more accurate, however it is not compatible as `last_reset` is somehow missing. I searched [the docs](https://developers.home-assistant.io/docs/core/entity/sensor/#entities-representing-a-total-amount) and it seems defining a `last_reset` is no longer necessary and we can use `total_increasing` as type instead. This PR changes this.

I am running my setup a few days with this change and it seems to work.

This may also close #18.