### PR TITLE
Fix deprecations in HomeAssistant 2025.1, 2025.5 & 2025.6

### DIFF
--- a/custom_components/kostal/__init__.py
+++ b/custom_components/kostal/__init__.py
@@ -5,7 +5,7 @@ import logging
 from .piko_holder import PikoHolder
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send, dispatcher_send
 
 from .const import DEFAULT_NAME, DOMAIN, SENSOR_TYPES
@@ -42,7 +42,7 @@ async def async_setup(hass, config):
     return True
 
 
-async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Setup KostalPiko component"""
 
     _LOGGER.info("Starting kostal, %s", __version__)
@@ -69,7 +69,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     return True
 
 
-async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
     instance = hass.data[DOMAIN][entry.entry_id]
     await instance.stop()
@@ -80,7 +80,7 @@ async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry):
 class KostalInstance():
     """Config instance of Kostal"""
 
-    def __init__(self, hass: HomeAssistantType, entry: ConfigEntry, conf):
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, conf):
         self.hass = hass
         self.config_entry = entry
         self.entry_id = self.config_entry.entry_id

--- a/custom_components/kostal/__init__.py
+++ b/custom_components/kostal/__init__.py
@@ -107,7 +107,7 @@ class KostalInstance():
         self.hass.add_job(self._asyncadd_sensors(sensors, piko))
 
     async def _asyncadd_sensors(self, sensors, piko: PikoHolder):
-        await self.hass.config_entries.async_forward_entry_setup(self.config_entry, "sensor")
+        await self.hass.config_entries.async_forward_entry_setups(self.config_entry, ["sensor"])
         async_dispatcher_send(self.hass, "kostal_init_sensors", sensors, piko)
 
     async def clean(self):

--- a/custom_components/kostal/const.py
+++ b/custom_components/kostal/const.py
@@ -2,18 +2,11 @@
 from datetime import timedelta
 
 from homeassistant.const import (
-    POWER_WATT,
-    ENERGY_KILO_WATT_HOUR,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfPower,
     )
-
-try:
-    from homeassistant.const import (
-        ELECTRIC_POTENTIAL_VOLT,
-        ELECTRIC_CURRENT_AMPERE,
-        )
-except ImportError:
-    from homeassistant.const import VOLT as ELECTRIC_POTENTIAL_VOLT
-    from homeassistant.const import ELECTRICAL_CURRENT_AMPERE as ELECTRIC_CURRENT_AMPERE
 
 DOMAIN = "kostal"
 
@@ -22,24 +15,24 @@ DEFAULT_NAME = "Kostal Piko"
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
 
 SENSOR_TYPES = {
-    "solar_generator_power": ["Solar generator power", POWER_WATT, "mdi:solar-power"],
-    "consumption_phase_1": ["Consumption phase 1", POWER_WATT, "mdi:power-socket-eu"],
-    "consumption_phase_2": ["Consumption phase 2", POWER_WATT, "mdi:power-socket-eu"],
-    "consumption_phase_3": ["Consumption phase 3", POWER_WATT, "mdi:power-socket-eu"],
-    "current_power": ["Current power", POWER_WATT, "mdi:solar-power"],
-    "total_energy": ["Total energy", ENERGY_KILO_WATT_HOUR, "mdi:solar-power"],
-    "daily_energy": ["Daily energy", ENERGY_KILO_WATT_HOUR, "mdi:solar-power"],
-    "string1_voltage": ["String 1 voltage", ELECTRIC_POTENTIAL_VOLT, "mdi:current-ac"],
-    "string1_current": ["String 1 current", ELECTRIC_CURRENT_AMPERE, "mdi:flash"],
-    "string2_voltage": ["String 2 voltage", ELECTRIC_POTENTIAL_VOLT, "mdi:current-ac"],
-    "string2_current": ["String 2 current", ELECTRIC_CURRENT_AMPERE, "mdi:flash"],
-    "string3_voltage": ["String 3 voltage", ELECTRIC_POTENTIAL_VOLT, "mdi:current-ac"],
-    "string3_current": ["String 3 current", ELECTRIC_CURRENT_AMPERE, "mdi:flash"],
-    "l1_voltage": ["L1 voltage", ELECTRIC_POTENTIAL_VOLT, "mdi:current-ac"],
-    "l1_power": ["L1 power", POWER_WATT, "mdi:power-plug"],
-    "l2_voltage": ["L2 voltage", ELECTRIC_POTENTIAL_VOLT, "mdi:current-ac"],
-    "l2_power": ["L2 power", POWER_WATT, "mdi:power-plug"],
-    "l3_voltage": ["L3 voltage", ELECTRIC_POTENTIAL_VOLT, "mdi:current-ac"],
-    "l3_power": ["L3 power", POWER_WATT, "mdi:power-plug"],
+    "solar_generator_power": ["Solar generator power", UnitOfPower.WATT, "mdi:solar-power"],
+    "consumption_phase_1": ["Consumption phase 1", UnitOfPower.WATT, "mdi:power-socket-eu"],
+    "consumption_phase_2": ["Consumption phase 2", UnitOfPower.WATT, "mdi:power-socket-eu"],
+    "consumption_phase_3": ["Consumption phase 3", UnitOfPower.WATT, "mdi:power-socket-eu"],
+    "current_power": ["Current power", UnitOfPower.WATT, "mdi:solar-power"],
+    "total_energy": ["Total energy", UnitOfEnergy.KILO_WATT_HOUR, "mdi:solar-power"],
+    "daily_energy": ["Daily energy", UnitOfEnergy.KILO_WATT_HOUR, "mdi:solar-power"],
+    "string1_voltage": ["String 1 voltage", UnitOfElectricPotential.VOLT, "mdi:current-ac"],
+    "string1_current": ["String 1 current", UnitOfElectricCurrent.AMPERE, "mdi:flash"],
+    "string2_voltage": ["String 2 voltage", UnitOfElectricPotential.VOLT, "mdi:current-ac"],
+    "string2_current": ["String 2 current", UnitOfElectricCurrent.AMPERE, "mdi:flash"],
+    "string3_voltage": ["String 3 voltage", UnitOfElectricPotential.VOLT, "mdi:current-ac"],
+    "string3_current": ["String 3 current", UnitOfElectricCurrent.AMPERE, "mdi:flash"],
+    "l1_voltage": ["L1 voltage", UnitOfElectricPotential.VOLT, "mdi:current-ac"],
+    "l1_power": ["L1 power", UnitOfPower.WATT, "mdi:power-plug"],
+    "l2_voltage": ["L2 voltage", UnitOfElectricPotential.VOLT, "mdi:current-ac"],
+    "l2_power": ["L2 power", UnitOfPower.WATT, "mdi:power-plug"],
+    "l3_voltage": ["L3 voltage", UnitOfElectricPotential.VOLT, "mdi:current-ac"],
+    "l3_power": ["L3 power", UnitOfPower.WATT, "mdi:power-plug"],
     "status": ["Status", None, "mdi:solar-power"],
 }

--- a/custom_components/kostal/sensor.py
+++ b/custom_components/kostal/sensor.py
@@ -14,18 +14,14 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_HOST,
     CONF_MONITORED_CONDITIONS,
-    DEVICE_CLASS_ENERGY,
-    ENERGY_KILO_WATT_HOUR,
+    UnitOfEnergy,
 )
 
 from homeassistant.components.sensor import (
-    STATE_CLASS_MEASUREMENT,
+    SensorDeviceClass,
     SensorEntity,
+    SensorStateClass,
 )
-try:
-    from homeassistant.components.sensor import STATE_CLASS_TOTAL_INCREASING
-except ImportError:
-    from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT as STATE_CLASS_TOTAL_INCREASING
 
 from .const import SENSOR_TYPES, MIN_TIME_BETWEEN_UPDATES, DOMAIN
 
@@ -70,9 +66,9 @@ class PikoSensor(SensorEntity):
         self._icon = SENSOR_TYPES[self.type][2]
         self.serial_number = info[0]
         self.model = info[1]
-        if self._unit_of_measurement == ENERGY_KILO_WATT_HOUR:
-            self._attr_device_class = DEVICE_CLASS_ENERGY
-            self._attr_state_class = STATE_CLASS_TOTAL_INCREASING
+        if self._unit_of_measurement == UnitOfEnergy.KILO_WATT_HOUR:
+            self._attr_device_class = SensorDeviceClass.ENERGY
+            self._attr_state_class = SensorStateClass.TOTAL_INCREASING
 
     @property
     def name(self):

--- a/custom_components/kostal/sensor.py
+++ b/custom_components/kostal/sensor.py
@@ -4,7 +4,7 @@ import logging, time
 from .piko_holder import PikoHolder
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from homeassistant.helpers.entity import Entity
@@ -28,7 +28,7 @@ from .const import SENSOR_TYPES, MIN_TIME_BETWEEN_UPDATES, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry, async_add_entities):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
     """Set up the sensor dynamically."""
     _LOGGER.info("Setting up kostal piko sensor")
     async def async_add_sensors(sensors, piko: PikoHolder):
@@ -53,7 +53,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry, async_a
 class PikoSensor(SensorEntity):
     """Representation of a Piko inverter value."""
 
-    def __init__(self,  hass: HomeAssistantType, piko: PikoHolder, sensor_type, info={None,None}, name=None):
+    def __init__(self,  hass: HomeAssistant, piko: PikoHolder, sensor_type, info={None,None}, name=None):
         """Initialize the sensor."""
         _LOGGER.debug("Initializing PikoSensor: %s", sensor_type)
         self._sensor = SENSOR_TYPES[sensor_type][0]


### PR DESCRIPTION
This PR fixes a bunch of deprecations in HomeAssistant of the coming releases, some named in #31 and similar to #29, but a lot less changes. So I am hoping to have a quick review @rcasula.

I tested this PR with my own Piko 8.3 and during setup, execution and deletion of the integration I see no errors and deprecation warnings.

Close #31